### PR TITLE
Fix simulated moments packing edge case

### DIFF
--- a/core/SimulatedMoments.m
+++ b/core/SimulatedMoments.m
@@ -1,0 +1,123 @@
+function [mvec, out] = SimulatedMoments(x, opt)
+% SIMULATEDMOMENTS  End-to-end pipeline: params(x) -> equilibrium -> simulation -> moments.
+%
+%   [MVEC, OUT] = SIMULATEDMOMENTS(X, OPT) builds parameters from X,
+%   solves the dynamic equilibrium, simulates agents, and computes the
+%   simulated moments specified in the project notes.
+%
+%   INPUTS
+%   ------
+%   x   : vector or struct of parameter overrides (see SetParameters(dims,x)).
+%   opt : optional struct to alter runtime settings (all fields optional)
+%         .fast       (bool) if true, reduce T and Nagents for speed.
+%         .seed       (int)  rng seed for reproducibility.
+%         .Ti         (int)  horizon index for tenure-cohort moments (default: settings.T).
+%         .max_tenure (int)  cap for tenure bins (default: Ti).
+%
+%   OUTPUTS
+%   -------
+%   mvec : column vector of stacked simulated moments (see OUT.map for index ranges).
+%   out  : struct with detailed outputs for diagnostics:
+%          .dims, .params, .settings
+%          .vf_nh, .pol_eqm
+%          .M_eqm, .G_dist
+%          .M_total, .M_network
+%          .agentData, .flowLog
+%          .moments  (struct with shaped arrays)
+%          .map      (struct with indices into mvec)
+%
+%   NOTES
+%   -----
+%   • This function does not require observed data; it only simulates.
+%   • Use OUT.map to align simulated moments to data moments in your GMM code.
+% -------------------------------------------------------------------------
+
+    if nargin < 1 || isempty(x)
+        x = struct();
+    end
+    if nargin < 2 || isempty(opt)
+        opt = struct();
+    end
+
+    %% 1) Initialize dimensions and settings ---------------------------------
+    dims     = setDimensionParam();
+    settings = IterationSettings();
+
+    if isfield(opt, 'fast') && opt.fast
+        settings.Nagents = 1000;
+        settings.T       = 40;
+        settings.burn    = min(20, settings.T - 1);
+        settings.fastFlag = true;
+    else
+        settings.fastFlag = false;
+    end
+
+    if isfield(opt, 'seed')
+        rng(opt.seed);
+        settings.seed = opt.seed;
+    end
+
+    if isfield(opt, 'Ti')
+        settings.Ti = min(max(1, opt.Ti), settings.T);
+    else
+        settings.Ti = settings.T;
+    end
+    if isfield(opt, 'max_tenure')
+        settings.max_tenure = opt.max_tenure;
+    else
+        settings.max_tenure = settings.Ti;
+    end
+
+    %% 2) Parameters, grids, and matrices ------------------------------------
+    params            = SetParameters(dims, x);
+    [grids, indexes]  = setGridsAndIndices(dims);
+    matrices          = constructMatrix(dims, params, grids, indexes);
+    params.P          = matrices.P;    % convenience handle for downstream code
+
+    %% 3) Steady-state (no-help) value functions -----------------------------
+    [vf_nh, ~] = noHelpEqm(dims, params, grids, indexes, matrices, settings);
+
+    %% 4) Initial distributions and dynamic equilibrium ----------------------
+    m0 = createInitialDistribution(dims, settings);
+
+    M0          = zeros(dims.N, settings.T);
+    M0(1, :)    = 1;
+    M0(1, 1)    = 1;   % explicit first-period anchor (redundant with previous line)
+
+    [pol_eqm, M_eqm] = solveDynamicEquilibrium(M0, vf_nh, m0, ...
+        dims, params, grids, indexes, matrices, settings); %#ok<ASGLU>
+
+    %% 5) Help path and simulation -------------------------------------------
+    G_dist = computeG(M_eqm, params.ggamma);                  % [H×T]
+    [M_total, M_network, agentData, flowLog] = simulateAgents( ...
+        m0, pol_eqm, G_dist, dims, params, grids, matrices, settings);
+
+    %% 6) Compute simulated moments -----------------------------------------
+    if ~isempty(flowLog)
+        agentData.flowLog = flowLog;  % attach for moment construction
+    end
+    moments = computeSimulatedMoments(agentData, M_total, M_network, ...
+        dims, params, grids, settings, matrices);
+    if isfield(agentData, 'flowLog')
+        agentData = rmfield(agentData, 'flowLog');
+    end
+
+    [mvec, map] = packMoments(moments, dims, settings);
+
+    %% 7) Pack outputs -------------------------------------------------------
+    out.dims      = dims;
+    out.params    = params;
+    out.settings  = settings;
+    out.vf_nh     = vf_nh;
+    out.pol_eqm   = pol_eqm;
+    out.M_eqm     = M_eqm;
+    out.G_dist    = G_dist;
+    out.M_total   = M_total;
+    out.M_network = M_network;
+    out.agentData = agentData;
+    out.flowLog   = flowLog;
+    out.moments   = moments;
+    out.map       = map;
+    out.matrices  = matrices;
+
+end

--- a/utils/computeSimulatedMoments.m
+++ b/utils/computeSimulatedMoments.m
@@ -1,0 +1,187 @@
+function mom = computeSimulatedMoments(agentData, M_total, M_network, dims, params, grids, settings, matrices) %#ok<INUSD>
+% COMPUTESIMULATEDMOMENTS  Build simulated moments from trajectories.
+%
+%   MOM = COMPUTESIMULATEDMOMENTS(AGENTDATA, M_TOTAL, M_NETWORK, DIMS, PARAMS,
+%   GRIDS, SETTINGS, MATRICES) computes a set of arrays of moments which will
+%   later be stacked into a vector for estimation. All moments are computed per
+%   period t and/or by skill s and/or by location i, as specified below.
+%
+%   OUTPUT (mom): struct with fields
+%     .unemp_rate_sit      [S×N×T]   unemployment rate by skill, location, time
+%     .avg_wage_emp_sit    [S×N×T]   average employed income by skill, location, time
+%     .mass_total_sit      [S×N×T]   total mass by skill, location, time (share of agents of skill s)
+%     .share_new_help_sit  [S×N×T]   among new arrivals at (i,t,s): share with help (t=1 = NaN)
+%     .share_new_direct_sit [S×N×T]  among new arrivals at (i,t,s): share direct from Venezuela (t=1 = NaN)
+%     .tenure_unemp_id     {N}       each cell is [Dmax+1 × 1] unemp rate by tenure at T_i
+%     .tenure_avg_wage_id  {N}       each cell is [Dmax+1 × 1] avg employed income by tenure at T_i
+%     .Ti                  scalar    horizon used for tenure moments
+%     .Dmax                scalar    tenure cap applied
+% -------------------------------------------------------------------------
+
+    S = dims.S;
+    N = dims.N;
+
+    locTraj   = double(agentData.location);   % [Nagents×T]
+    stateTraj = double(agentData.state);      % [Nagents×T]
+    skillVec  = double(agentData.skill(:));   % [Nagents×1]
+    Nagents   = size(locTraj, 1);
+    T         = size(locTraj, 2);
+
+    isU = stateTraj <= dims.k;
+    isE = ~isU;
+
+    psi_idx  = mod(stateTraj - 1, dims.k) + 1;
+    psi_vals = grids.psi(psi_idx);
+
+    A_vals      = params.A(locTraj);
+    theta_vals  = zeros(size(locTraj));
+    for s = 1:S
+        idx_s = (skillVec == s);
+        if any(idx_s)
+            theta_row = params.theta_s(s, :);
+            theta_idx = locTraj(idx_s, :);
+            theta_vals(idx_s, :) = reshape(theta_row(theta_idx), sum(idx_s), T);
+        end
+    end
+    wage_vals = A_vals .* theta_vals .* (1 + psi_vals) .^ params.theta_k;
+    wage_vals(~isE) = NaN;   % only employed earnings matter for averages
+
+    moved = false(Nagents, T);
+    if T >= 2
+        moved(:, 2:end) = locTraj(:, 2:end) ~= locTraj(:, 1:end-1);
+    end
+
+    hasFlowLog = isfield(agentData, 'flowLog');
+    if hasFlowLog
+        flowLog = agentData.flowLog;
+        helpUsed   = logical(flowLog.helpUsed);
+        directVzla = logical(flowLog.directFromVzla);
+    else
+        helpUsed   = false(Nagents, T);
+        directVzla = false(Nagents, T);
+    end
+
+    %% Aggregate by skill/location/time --------------------------------------
+    mom.unemp_rate_sit      = nan(S, N, T);
+    mom.avg_wage_emp_sit    = nan(S, N, T);
+    mom.mass_total_sit      = zeros(S, N, T);
+    mom.share_new_help_sit   = nan(S, N, T);
+    mom.share_new_direct_sit = nan(S, N, T);
+
+    for s = 1:S
+        skillMask    = (skillVec == s);
+        totalSkill   = sum(skillMask);
+        if totalSkill == 0
+            mom.mass_total_sit(s, :, :) = NaN;
+            continue;
+        end
+
+        loc_s   = locTraj(skillMask, :);
+        isU_s   = isU(skillMask, :);
+        wage_s  = wage_vals(skillMask, :);
+        moved_s = moved(skillMask, :);
+        help_s  = helpUsed(skillMask, :);
+        direct_s= directVzla(skillMask, :);
+
+        for t = 1:T
+            loc_t = loc_s(:, t);
+            for i = 1:N
+                subset = (loc_t == i);
+                count_i = sum(subset);
+                if count_i == 0
+                    mom.mass_total_sit(s, i, t) = 0;
+                    if t >= 2
+                        mom.share_new_help_sit(s, i, t)   = NaN;
+                        mom.share_new_direct_sit(s, i, t) = NaN;
+                    end
+                    continue;
+                end
+
+                mom.mass_total_sit(s, i, t) = count_i / totalSkill;
+                mom.unemp_rate_sit(s, i, t) = mean(isU_s(subset, t));
+                mom.avg_wage_emp_sit(s, i, t) = mean(wage_s(subset, t), 'omitnan');
+
+                if t >= 2
+                    arrivals = subset & moved_s(:, t);
+                    if any(arrivals)
+                        mom.share_new_help_sit(s, i, t)   = mean(help_s(arrivals, t));
+                        mom.share_new_direct_sit(s, i, t) = mean(direct_s(arrivals, t));
+                    else
+                        mom.share_new_help_sit(s, i, t)   = NaN;
+                        mom.share_new_direct_sit(s, i, t) = NaN;
+                    end
+                end
+            end
+        end
+    end
+
+    if T >= 1
+        mom.share_new_help_sit(:, :, 1)   = NaN;
+        mom.share_new_direct_sit(:, :, 1) = NaN;
+    end
+
+    %% Tenure-cohort moments -------------------------------------------------
+    if isfield(settings, 'Ti') && ~isempty(settings.Ti)
+        Ti = min(max(1, settings.Ti), T);
+    else
+        Ti = T;
+    end
+    if isfield(settings, 'max_tenure') && ~isempty(settings.max_tenure)
+        Dmax = max(0, min(settings.max_tenure, Ti - 1));
+    else
+        Dmax = max(0, Ti - 1);
+    end
+
+    tenureLevels = zeros(Nagents, 1);
+    for n = 1:Nagents
+        loc_now = locTraj(n, Ti);
+        tenure  = 0;
+        tau     = Ti - 1;
+        while (tau >= 1) && (tenure < Dmax) && locTraj(n, tau) == loc_now
+            tenure = tenure + 1;
+            tau    = tau - 1;
+        end
+        tenureLevels(n) = tenure;
+    end
+
+    mom.tenure_unemp_id    = cell(N, 1);
+    mom.tenure_avg_wage_id = cell(N, 1);
+
+    unemp_Ti = isU(:, Ti);
+    wage_Ti  = wage_vals(:, Ti);
+    loc_Ti   = locTraj(:, Ti);
+
+    for i = 1:N
+        idx_i = (loc_Ti == i);
+        if ~any(idx_i)
+            mom.tenure_unemp_id{i}    = nan(Dmax + 1, 1);
+            mom.tenure_avg_wage_id{i} = nan(Dmax + 1, 1);
+            continue;
+        end
+
+        tenure_i = tenureLevels(idx_i);
+        unemp_i  = unemp_Ti(idx_i);
+        wage_i   = wage_Ti(idx_i);
+
+        unemp_bins = nan(Dmax + 1, 1);
+        wage_bins  = nan(Dmax + 1, 1);
+        for d = 0:Dmax
+            binMask = (tenure_i == d);
+            if any(binMask)
+                unemp_bins(d+1) = mean(unemp_i(binMask));
+                wage_bins(d+1)  = mean(wage_i(binMask), 'omitnan');
+            end
+        end
+
+        mom.tenure_unemp_id{i}    = unemp_bins;
+        mom.tenure_avg_wage_id{i} = wage_bins;
+    end
+
+    mom.Ti   = Ti;
+    mom.Dmax = Dmax;
+
+    %% Optional: retain aggregate masses for diagnostics ---------------------
+    mom.M_total   = M_total;
+    mom.M_network = M_network;
+
+end

--- a/utils/constructMatrix.m
+++ b/utils/constructMatrix.m
@@ -23,6 +23,7 @@ function matrices = constructMatrix(dims, params, grids, indexes)
 %       .Ue        Utility from feasible consumption (−∞ for infeasible).
 %       .a_prime   Assets net of migration costs (S×K×Na×N×N×H).
 %       .mig_costs Raw effective migration costs τ^{iℓ}(h) (N×N×H).
+%       .Hbin      Binary help matrix enumerating h (H×N).
 %       .P         Transition operator for (employment × ψ),
 %                  shape S×K×K×N (built via build_P).
 %
@@ -70,7 +71,7 @@ function matrices = constructMatrix(dims, params, grids, indexes)
 
     %% 2. After-migration wealth -------------------------------------------------
     % Effective migration cost tensor: τ^{iℓ}(h), N×N×H
-    mig_costs = build_tau_eff(dims, params);
+    [mig_costs, Hbin] = build_tau_eff(dims, params);
 
     % Expand to match (S,K,Na,N,N,H) dimensions:
     %   permute to add singleton skill/asset/state dimensions,
@@ -89,5 +90,6 @@ function matrices = constructMatrix(dims, params, grids, indexes)
     matrices.Ue        = Ue;
     matrices.a_prime   = a_prime;
     matrices.mig_costs = mig_costs;
+    matrices.Hbin      = Hbin;
 
 end

--- a/utils/packMoments.m
+++ b/utils/packMoments.m
@@ -1,0 +1,120 @@
+function [mvec, map] = packMoments(mom, dims, settings)
+% PACKMOMENTS  Stack structured moment arrays into a single column vector.
+%
+%   [MVEC, MAP] = PACKMOMENTS(MOM, DIMS, SETTINGS) linearizes selected fields
+%   of MOM into one vector MVEC. MAP contains index ranges for each block.
+%
+%   Blocks (in order):
+%     1) unemp_rate_sit       : vec of size S*N*T
+%     2) avg_wage_emp_sit     : vec of size S*N*T
+%     3) mass_total_sit       : vec of size S*N*T
+%     4) share_new_help_sit   : vec of size S*N*(T-1)  (t>=2 only)
+%     5) share_new_direct_sit : vec of size S*N*(T-1)
+%     6) tenure (for each i): [unemp_by_tenure; avg_wage_by_tenure]
+%
+%   NaNs are converted to 0 in MVEC, and MAP.nan_mask stores positions of NaNs.
+% -------------------------------------------------------------------------
+
+    %#ok<INUSD>
+
+    S = dims.S;
+    N = dims.N;
+    T = size(mom.unemp_rate_sit, 3);
+
+    blocks     = cell(6, 1);
+    block_info = cell(6, 1);
+    idx_start  = 1;
+
+    % Block 1: Unemployment rates
+    blk = mom.unemp_rate_sit(:);
+    blocks{1} = blk;
+    block_info{1} = struct('name', 'unemp_rate_sit', 'start', idx_start, ...
+        'stop', idx_start + numel(blk) - 1, 'shape', [S, N, T]);
+    idx_start = block_info{1}.stop + 1;
+
+    % Block 2: Average wages (employed)
+    blk = mom.avg_wage_emp_sit(:);
+    blocks{2} = blk;
+    block_info{2} = struct('name', 'avg_wage_emp_sit', 'start', idx_start, ...
+        'stop', idx_start + numel(blk) - 1, 'shape', [S, N, T]);
+    idx_start = block_info{2}.stop + 1;
+
+    % Block 3: Mass shares
+    blk = mom.mass_total_sit(:);
+    blocks{3} = blk;
+    block_info{3} = struct('name', 'mass_total_sit', 'start', idx_start, ...
+        'stop', idx_start + numel(blk) - 1, 'shape', [S, N, T]);
+    idx_start = block_info{3}.stop + 1;
+
+    % Block 4: Share of new arrivals with help (exclude t=1)
+    if T >= 2
+        blk_help = mom.share_new_help_sit(:, :, 2:end);
+        blk_help = blk_help(:);
+    else
+        blk_help = [];
+    end
+    blocks{4} = blk_help;
+    block_info{4} = struct('name', 'share_new_help_sit', 'start', idx_start, ...
+        'stop', idx_start + numel(blk_help) - 1, 'shape', [S, N, max(T-1, 0)], ...
+        't_range', 2:T);
+    idx_start = block_info{4}.stop + 1;
+
+    % Block 5: Share arriving directly from origin (exclude t=1)
+    if T >= 2
+        blk_dir = mom.share_new_direct_sit(:, :, 2:end);
+        blk_dir = blk_dir(:);
+    else
+        blk_dir = [];
+    end
+    blocks{5} = blk_dir;
+    block_info{5} = struct('name', 'share_new_direct_sit', 'start', idx_start, ...
+        'stop', idx_start + numel(blk_dir) - 1, 'shape', [S, N, max(T-1, 0)], ...
+        't_range', 2:T);
+    idx_start = block_info{5}.stop + 1;
+
+    % Block 6: Tenure stacks per location
+    tenure_blocks = [];
+    tenure_map    = cell(N, 1);
+    Dmax = mom.Dmax;
+    for i = 1:N
+        ten_u = mom.tenure_unemp_id{i};
+        ten_w = mom.tenure_avg_wage_id{i};
+        if isempty(ten_u)
+            ten_u = nan(Dmax + 1, 1);
+        end
+        if isempty(ten_w)
+            ten_w = nan(Dmax + 1, 1);
+        end
+        stack_i = [ten_u(:); ten_w(:)];
+        tenure_map{i} = struct('location', i, 'start', idx_start + numel(tenure_blocks), ...
+            'stop', idx_start + numel(tenure_blocks) + numel(stack_i) - 1, ...
+            'length', numel(stack_i));
+        tenure_blocks = [tenure_blocks; stack_i]; %#ok<AGROW>
+    end
+    blocks{6} = tenure_blocks;
+    block_info{6} = struct('name', 'tenure_blocks', 'start', idx_start, ...
+        'stop', idx_start + numel(tenure_blocks) - 1, ...
+        'details', tenure_map);
+
+    % Concatenate blocks
+    fullvec = vertcat(blocks{:});
+    nan_mask = isnan(fullvec);
+    mvec = fullvec;
+    mvec(nan_mask) = 0;
+
+    map.block_info = block_info;
+    map.nan_mask   = nan_mask;
+    map.length     = numel(mvec);
+    map.order      = {'unemp_rate_sit', 'avg_wage_emp_sit', 'mass_total_sit', ...
+                      'share_new_help_sit', 'share_new_direct_sit', 'tenure_blocks'};
+    map.tenure     = tenure_map;
+    map.S          = S;
+    map.N          = N;
+    map.T          = T;
+    if isstruct(settings) && isfield(settings, 'T')
+        map.settings_T = settings.T;
+    else
+        map.settings_T = T;
+    end
+
+end

--- a/utils/simulateAgents.m
+++ b/utils/simulateAgents.m
@@ -1,10 +1,12 @@
-function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, dims, params, grids, matrices, settings)
+function [M_history, MIN_history, agentData, flowLog] = simulateAgents(m0, pol, G_dist, dims, params, grids, matrices, settings)
 % SIMULATEAGENTS  Simulate agent evolution over T periods using policy paths.
 %
-%   [M_HISTORY, MIN_HISTORY, AGENTDATA] = SIMULATEAGENTS(M0, POL, G_DIST, DIMS, PARAMS, GRIDS, MATRICES, SETTINGS)
+%   [M_HISTORY, MIN_HISTORY, AGENTDATA] = SIMULATEAGENTS(M0, POL, G_DIST, ...)
 %   simulates the dynamic paths of agents given time-varying policy functions
 %   and help-offer distributions. It returns total location shares, networked
-%   shares, and individual trajectories.
+%   shares, and individual trajectories. When a fourth output is requested, the
+%   function also logs migration-flow diagnostics (help usage and direct-from-
+%   origin moves) without affecting existing calls.
 %
 %   INPUTS
 %   ------
@@ -48,6 +50,9 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
 %                   .state    [Nagents×T]
 %                   .network  [Nagents×T]
 %                   .skill    [Nagents×1]
+%   flowLog     : (optional) struct with migration-flow flags (only if requested)
+%                   .helpUsed       [Nagents×T] logical, true when moved with help
+%                   .directFromVzla [Nagents×T] logical, true when moved from origin
 %
 %   NOTES
 %   -----
@@ -60,9 +65,10 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
 % ======================================================================
 
     %% 1) Setup ------------------------------------------------------------
-    T       = settings.T;
-    Nagents = settings.Nagents;
-    N       = dims.N;
+    T         = settings.T;
+    Nagents   = settings.Nagents;
+    N         = dims.N;
+    logFlows  = nargout >= 4;
 
     % Accept either time-varying (cell) or fixed (numeric) policies
     isTimeInvariant = ~iscell(pol.a);
@@ -74,8 +80,13 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
     end
 
     % (z,ψ) transition and effective migration costs (precomputed in MATRICES)
-    P_local  = matrices.P;         % [S×K×K×N]
-    mig_costs = matrices.mig_costs; % [N×N×H]
+    P_local   = matrices.P;          % [S×K×K×N]
+    mig_costs = matrices.mig_costs;  % [N×N×H]
+    if logFlows && isfield(matrices, 'Hbin')
+        Hbin = matrices.Hbin;        % [H×N]
+    else
+        Hbin = [];
+    end
 
     %% 2) Preallocate trajectories ----------------------------------------
     locationTraj = zeros(Nagents, T, 'uint16');
@@ -83,6 +94,10 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
     stateTraj    = zeros(Nagents, T, 'uint16');   % K-index
     networkTraj  = zeros(Nagents, T, 'uint8');
     skillTraj    = zeros(Nagents, 1, 'uint16');   % skill fixed
+    if logFlows
+        helpUsedTraj   = false(Nagents, T);
+        directVzlaTraj = false(Nagents, T);
+    end
 
     %% 3) Simulation loop --------------------------------------------------
     parfor agentIdx = 1:Nagents
@@ -100,6 +115,8 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
         weaHist = zeros(1, T, 'uint16');
         staHist = zeros(1, T, 'uint16');
         netHist = zeros(1, T, 'uint8');
+        helpHist   = false(1, T);
+        directHist = false(1, T);
 
         locHist(1) = loc;
         weaHist(1) = wea;
@@ -154,7 +171,20 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
             end
 
             %% C) Wealth and K-state transition
-            if nextLoc ~= loc
+            moved = nextLoc ~= loc;
+
+            if logFlows
+                helpFlag   = false;
+                directFlag = false;
+                if moved
+                    helpFlag   = (net == 1) && ~isempty(Hbin) && Hbin(double(h_idx), double(nextLoc)) == 1;
+                    directFlag = (loc == 1);
+                end
+                helpHist(t+1)   = helpFlag;
+                directHist(t+1) = directFlag;
+            end
+
+            if moved
                 % Pay migration cost (depends on help vector)
                 migCost = mig_costs(loc, nextLoc, h_idx);
                 newA    = grids.agrid(nextWea) - migCost;
@@ -215,6 +245,10 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
         stateTraj(  agentIdx, :)  = staHist;
         networkTraj(agentIdx, :)  = netHist;
         skillTraj(  agentIdx, 1)  = ski;
+        if logFlows
+            helpUsedTraj(agentIdx, :)   = helpHist;
+            directVzlaTraj(agentIdx, :) = directHist;
+        end
     end
 
     %% 4) Aggregate location histories -----------------------------------
@@ -235,4 +269,10 @@ function [M_history, MIN_history, agentData] = simulateAgents(m0, pol, G_dist, d
     agentData.state    = stateTraj;
     agentData.network  = networkTraj;
     agentData.skill    = skillTraj;
+    if logFlows
+        flowLog.helpUsed       = helpUsedTraj;
+        flowLog.directFromVzla = directVzlaTraj;
+    else
+        flowLog = [];
+    end
 end


### PR DESCRIPTION
## Summary
- stop incrementing the post-tenure block pointer in `packMoments` so the block info struct remains numeric and plus-operations no longer throw
- preallocate per-agent help and direct-flow histories in every parfor iteration to silence uninitialized temporary warnings while preserving optional logging

## Testing
- matlab -batch "addpath('core'); addpath('utils'); opt.fast=true; opt.seed=1; [mvec,out] = SimulatedMoments(struct(), opt); disp(size(mvec));" *(fails: MATLAB unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4379fd60c832185c2e31eae7c282e