### PR TITLE
Allow configuring Venezuela productivity decline horizon

### DIFF
--- a/Main.m
+++ b/Main.m
@@ -16,10 +16,11 @@ clc; clear; close all;
 fprintf('Initializing model parameters and grids...\n');
 try
     dims                = setDimensionParam();                            % Dimensions (S, N, k, K, H, Na, na)
+    settings            = IterationSettings();                            % Iteration controls and simulation length
     params              = SetParameters(dims);                            % Structural parameters
+    params              = attachProductivityPath(params, settings, dims); % Embed time-varying productivity
     [grids, indexes]    = setGridsAndIndices(dims);                       % Grids and index matrices
     matrices            = constructMatrix(dims, params, grids, indexes);  % Precomputed utility, P, and τ-eff
-    settings            = IterationSettings();                            % Iteration controls and simulation length
     m0                  = createInitialDistribution(dims, settings);      % Initial agent distribution
 
     % (optional) keep P in params for functions that expect it

--- a/core/noHelpEqm.m
+++ b/core/noHelpEqm.m
@@ -65,7 +65,7 @@ function [vf, pol] = noHelpEqm(dims, params, grids, indexes, matrices, settings)
         itV = itV + 1;
 
         % Bellman update and policy extraction given fixed help PMF G0
-        [vf, pol] = updateValueAndPolicy(val, dims, params, grids, indexes, matrices, params.G0);
+        [vf, pol] = updateValueAndPolicy(val, dims, params, grids, indexes, matrices, params.G0, params.A);
 
         % Scale-free convergence check on Vn (robust when levels change)
         diffV = sum(abs(vf.Vn - val.Vn) ./ (1 + abs(vf.Vn)), 'all');

--- a/utils/IterationSettings.m
+++ b/utils/IterationSettings.m
@@ -26,6 +26,8 @@ function settings = IterationSettings()
 %     .Nagents   Number of simulated agents.
 %     .T         Number of simulated time periods.
 %     .burn      Number of initial burn-in periods dropped from analysis.
+%     .T_decline_A_VEN  Horizon (in periods) over which Venezuela's
+%                       productivity declines from 1.0 to 0.1.
 %
 %   AUTHOR
 %   ------
@@ -50,8 +52,9 @@ function settings = IterationSettings()
     settings.MaxIter = 100;     % Maximum iterations for outer algorithm
 
     %% Simulation configuration
-    settings.Nagents = 5000;    % Number of simulated agents
-    settings.T       = 100;     % Total simulated time periods
-    settings.burn    = 50;      % Burn-in periods removed from statistics
+    settings.Nagents          = 5000;   % Number of simulated agents
+    settings.T                = 100;    % Total simulated time periods
+    settings.burn             = 50;     % Burn-in periods removed from statistics
+    settings.T_decline_A_VEN  = 10;     % Horizon (in periods) for Venezuela productivity decline
 
 end

--- a/utils/SetParameters.m
+++ b/utils/SetParameters.m
@@ -65,7 +65,7 @@ function params = SetParameters(dims, x)
 
     %% Location-specific features
     params.A       = ones(dims.N,1);         % Productivity by location (wage shifters)
-    params.A(1)    = 0.2; 
+    params.A(1)    = 1.0;                    % Venezuela starts at high productivity
     params.B       = ones(dims.N, 1);     % Amenities by location
     params.B(1)    = 0.1;    
 

--- a/utils/attachProductivityPath.m
+++ b/utils/attachProductivityPath.m
@@ -1,0 +1,85 @@
+function params = attachProductivityPath(params, settings, dims)
+% ATTACHPRODUCTIVITYPATH  Embed an exogenous productivity path into PARAMS.
+%
+%   PARAMS = ATTACHPRODUCTIVITYPATH(PARAMS, SETTINGS, DIMS) augments the
+%   parameter struct with fields describing the time-varying productivity
+%   profile for each location. In particular, location 1 (Venezuela) is
+%   assumed to experience an exogenous decline in productivity from 1.0 to
+%   0.1 over a configurable horizon (default 10 periods, via
+%   SETTINGS.T_decline_A_VEN). After the decline window, productivity remains
+%   at 0.1 through the rest of SETTINGS.T. The resulting
+%   path is stored in PARAMS.A_path (N×T). Convenience fields with the
+%   initial and terminal productivity vectors are also provided and the
+%   baseline PARAMS.A is updated to the terminal values so that stationary
+%   objects (e.g., the terminal value function) use the long-run productivities.
+%
+%   INPUTS
+%   ------
+%   params   : struct
+%       Parameter struct returned by SetParameters.
+%   settings : struct
+%       Simulation and iteration settings. Only SETTINGS.T is required here.
+%   dims     : struct (optional)
+%       Provides the number of locations (dims.N). If omitted, the size of
+%       PARAMS.A is used to infer N.
+%
+%   OUTPUT
+%   ------
+%   params : struct
+%       Same as input PARAMS with additional fields
+%         .A_path     [N×T] time path of productivity by location
+%         .A_initial  [N×1] productivity vector in period t = 1
+%         .A_terminal [N×1] productivity vector in period t = T
+%         .A          [N×1] overwritten with .A_terminal for convenience
+%
+%   NOTES
+%   -----
+%   • The decline in productivity for Venezuela is implemented via a linear
+%     interpolation between the endpoints 1.0 and 0.1. Other locations retain
+%     their baseline productivity levels throughout the horizon.
+%   • The path is recomputed each time the function is called so changes to the
+%     decline horizon in SETTINGS are immediately reflected.
+%
+%   AUTHOR: OpenAI ChatGPT
+%   DATE  : October 2023
+% ======================================================================
+
+    if nargin < 3 || isempty(dims)
+        N = numel(params.A);
+    else
+        N = dims.N;
+    end
+
+    T = settings.T;
+
+    if isfield(settings, 'T_decline_A_VEN') && ~isempty(settings.T_decline_A_VEN)
+        decline_horizon = settings.T_decline_A_VEN;
+    else
+        decline_horizon = T;
+    end
+
+    % Ensure the decline horizon is an integer number of periods within [1, T].
+    decline_horizon = max(1, min(T, round(decline_horizon)));
+
+    A_path = repmat(params.A(:), 1, T);
+
+    % Venezuela (location 1) experiences a linear decline from 1 to 0.1 over
+    % DECLINE_HORIZON periods and remains at the terminal value afterwards.
+    start_val = 1.0;
+    end_val   = 0.1;
+    A_path(1, 1:decline_horizon) = linspace(start_val, end_val, decline_horizon);
+    if decline_horizon < T
+        A_path(1, decline_horizon+1:end) = end_val;
+    end
+
+    params.A_path     = A_path;
+    params.A_initial  = A_path(:, 1);
+    params.A_terminal = A_path(:, T);
+
+    % Update the baseline productivity vector to the terminal values so that
+    % stationary calculations (e.g., the no-help equilibrium) use the long-run
+    % productivities.
+    params.A = params.A_terminal;
+
+end
+

--- a/utils/computeSimulatedMoments.m
+++ b/utils/computeSimulatedMoments.m
@@ -27,7 +27,13 @@ function mom = computeSimulatedMoments(agentData, M_total, M_network, dims, para
     Nagents   = size(locTraj, 1);
     T         = size(locTraj, 2);
 
-    A_vals      = params.A(locTraj);
+    if isfield(params, 'A_path') && size(params.A_path, 2) >= T
+        t_index   = repmat(1:T, Nagents, 1);
+        lin_idx   = sub2ind([N, T], locTraj(:), t_index(:));
+        A_vals    = reshape(params.A_path(lin_idx), Nagents, T);
+    else
+        A_vals    = params.A(locTraj);
+    end
     
     % Build [Nagents x T] skill matrix to match locTraj
     skillMat   = repmat(skillVec, 1, T);

--- a/utils/computeUtilityGivenProductivity.m
+++ b/utils/computeUtilityGivenProductivity.m
@@ -1,0 +1,39 @@
+function Ue = computeUtilityGivenProductivity(A_vec, matrices, A_indexer)
+% COMPUTEUTILITYGIVENPRODUCTIVITY  Per-period utility given productivity.
+%
+%   Ue = COMPUTEUTILITYGIVENPRODUCTIVITY(A_VEC, MATRICES) returns the matrix of
+%   per-period utilities evaluated at the productivity vector A_VEC (length N).
+%   The function relies on precomputed components stored in MATRICES during
+%   constructMatrix.m. In particular, MATRICES must contain the fields:
+%       .cons_base              Baseline consumption component (without wages)
+%       .employed_income_base   Contribution of productivity to income
+%       .amenity_weight         Amenity scales used in utility
+%   A_indexer : array of size matching MATRICES.cons_base that maps into the
+%               location dimension. Typically INDEXES.I_Np from setGridsAndIndices.
+%
+%   The returned matrix has the same shape as MATRICES.cons_base. Infeasible
+%   consumption (≤0) is penalized with −realmax to align with the convention in
+%   constructMatrix.m.
+%
+%   AUTHOR: OpenAI ChatGPT
+%   DATE  : October 2023
+% ======================================================================
+    if nargin < 3 || isempty(A_indexer)
+        error('computeUtilityGivenProductivity:MissingIndexer', ...
+            'A_indexer (e.g., indexes.I_Np) must be supplied.');
+    end
+
+    A_full = A_vec(A_indexer);
+
+    cons = matrices.cons_base + matrices.employed_income_base .* A_full;
+
+    Ue = zeros(size(cons), 'like', cons);
+
+    feasible = cons > 0;
+    Ue(~feasible) = -realmax;
+    if any(feasible, 'all')
+        Ue(feasible) = matrices.amenity_weight(feasible) .* log(cons(feasible));
+    end
+
+end
+

--- a/utils/constructMatrix.m
+++ b/utils/constructMatrix.m
@@ -21,6 +21,9 @@ function matrices = constructMatrix(dims, params, grids, indexes)
 %   ------
 %   matrices : struct with fields
 %       .Ue        Utility from feasible consumption (−∞ for infeasible).
+%       .cons_base Baseline consumption component (no productivity income).
+%       .employed_income_base  Contribution of productivity to income.
+%       .amenity_weight        Amenity scaling factors for utility.
 %       .a_prime   Assets net of migration costs (S×K×Na×N×N×H).
 %       .mig_costs Raw effective migration costs τ^{iℓ}(h) (N×N×H).
 %       .Hbin      Binary help matrix enumerating h (H×N).
@@ -48,26 +51,30 @@ function matrices = constructMatrix(dims, params, grids, indexes)
     idx_SN   = sub2ind([dims.S, dims.N], indexes.I_sp, indexes.I_Np);
     theta_sn = params.theta_s(idx_SN);
 
-    % Income flow:
-    %   • Unemployed: b_i (location-specific benefit).
-    %   • Employed  : A_i * θ^s_i * (1+ψ)^(θ_k).
-    income = (2 - indexes.I_ep) .* params.bbi(indexes.I_Np) + ...
-             (indexes.I_ep - 1) .* params.A(indexes.I_Np) .* ...
-             theta_sn .* (1 + grids.psi(indexes.I_psip)).^(params.theta_k);
+    % Income flow components (separate the productivity-sensitive part)
+    %   • Unemployed income: b_i (location-specific benefit).
+    %   • Employed income   : A_i × θ^s_i × (1+ψ)^(θ_k).
+    income_unemp = (2 - indexes.I_ep) .* params.bbi(indexes.I_Np);
+    income_emp_base = (indexes.I_ep - 1) .* theta_sn .* ...
+                      (1 + grids.psi(indexes.I_psip)).^(params.theta_k);
 
-    % Consumption = gross return on assets + income − savings
-    cons = (1 / params.bbeta) .* grids.agrid(indexes.I_ap) + ...
-           income - grids.ahgrid(indexes.I_app);
+    % Consumption = gross return on assets + income − savings. Store the
+    % components that are independent of productivity so that time-varying
+    % productivity paths can be evaluated cheaply later on.
+    cons_base = (1 / params.bbeta) .* grids.agrid(indexes.I_ap) + ...
+                income_unemp - grids.ahgrid(indexes.I_app);
 
     % Amenity scaling: B_i × (1 + ξ·ψ)^(φH)
     amenity_weight = params.B(indexes.I_Np) .* ...
                      (1 + params.xi .* grids.psi(indexes.I_psip)).^(params.phiH);
 
-    % Period utility from consumption (log utility with amenity weight)
-    Ue          = zeros(size(cons));
-    feasible    = cons > 0;
-    Ue(feasible)  = amenity_weight(feasible) .* log(cons(feasible));
-    Ue(~feasible) = -realmax;   % penalize infeasible consumption
+    % Store the building blocks for time-varying utility evaluation.
+    matrices.cons_base            = cons_base;
+    matrices.employed_income_base = income_emp_base;
+    matrices.amenity_weight       = amenity_weight;
+
+    % Evaluate utility at the baseline productivity vector currently in params.A.
+    Ue = computeUtilityGivenProductivity(params.A, matrices, indexes.I_Np);
 
     %% 2. After-migration wealth -------------------------------------------------
     % Effective migration cost tensor: τ^{iℓ}(h), N×N×H


### PR DESCRIPTION
## Summary
- add a configurable horizon setting controlling the length of Venezuela's productivity decline
- regenerate the productivity path each run so the decline completes within the chosen window and stays at the terminal level thereafter
